### PR TITLE
fix: fix github pages empty by add base path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,8 +6,8 @@ import vueDevTools from 'vite-plugin-vue-devtools';
 import tailwindcss from '@tailwindcss/vite';
 
 // https://vite.dev/config/
-export default defineConfig({
-  base: './',
+export default defineConfig(({ mode }) => ({
+  base: mode === 'production' ? '/sysCalibration/' : '/',
   plugins: [
     vue(),
     vueDevTools(),
@@ -18,4 +18,4 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
-});
+}));


### PR DESCRIPTION
### 修正
- 問題：部屬到 Github Pages 時畫面為空白
- 解決：在 vite.config.js 上添加 base，利用 mode 判斷是否為上線版本