### PR TITLE
Refactor/get user profile

### DIFF
--- a/src/apis/user/getProfile.js
+++ b/src/apis/user/getProfile.js
@@ -1,0 +1,10 @@
+import request from '@/utils/request';
+
+export default function getProfile(params = {}) {
+  return request({
+    url: '/user/getProfile',
+    method: 'post',
+    token: true,
+    data: params,
+  });
+}

--- a/src/components/layouts/Navbar.vue
+++ b/src/components/layouts/Navbar.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
-import { useProfileStore } from '@/stores/userProfile.js';
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+import apiGetProfile from '@/apis/user/getProfile.js';
 import IconButton from '@/components/buttons/IconButton.vue';
 
 defineProps({
@@ -8,7 +8,11 @@ defineProps({
 });
 defineEmits(['toggleSidebar']);
 
-const useProfile = useProfileStore();
+const userProfile = ref({
+  role: 'company',
+  username: '使用者名稱',
+});
+const isEmployee = ref(false);
 
 const isUserDropdownOpen = ref(false);
 const userDropdownRef = ref(null);
@@ -25,10 +29,21 @@ const handleClickOutside = (e) => {
   }
 };
 
-const isEmployee = computed(() => useProfile.userProfile.role === 'employee');
+const getUserProfile = async () => {
+  try {
+    const res = await apiGetProfile();
+    userProfile.value = res.payload;
+    isEmployee.value = res.payload.role === 'employee';
+  } catch (error) {
+    console.log(error);
+  }
+};
 
-// 監聽點擊事件
 onMounted(() => {
+  // 取得使用者資料
+  getUserProfile();
+
+  // 監聽點擊事件關閉使用者選單
   document.addEventListener('click', handleClickOutside);
 });
 
@@ -95,10 +110,10 @@ onBeforeUnmount(() => {
       <IconButton
         type="button"
         size="sm"
-        :role="useProfile.userProfile.role"
+        :role="userProfile.role"
         rounded="full"
       >
-        <span>{{ useProfile.userProfile.username }}</span>
+        <span>{{ userProfile.username }}</span>
         <img
           src="@/assets/icons/filled-arrow-white.svg"
           alt="arrow"

--- a/src/mock/index.js
+++ b/src/mock/index.js
@@ -6,3 +6,4 @@ const { mock } = Mock;
 
 // 設定 mock 資料 mock(url, get/post, response data);
 mock('/api/user/login', 'post', user.login);
+mock('/api/user/getProfile', 'post', user.getProfile);

--- a/src/mock/modules/user.js
+++ b/src/mock/modules/user.js
@@ -1,19 +1,45 @@
 import { Random } from 'mockjs';
+import { getCookie } from '@/utils/cookie.js';
 
 // 員工和廠商假資料
-const users = {
-  'employee01@test.com': { role: 'employee', username: '員工一', password: 'e01e01' },
-  'employee02@test.com': { role: 'employee', username: '員工二', password: 'e02e02' },
-  'company01@test.com': { role: 'company', username: '廠商一', password: 'c01c01' },
-  'company02@test.com': { role: 'company', username: '廠商二', password: 'c02c02' },
-  'company03@test.com': { role: 'company', username: '廠商三', password: 'c02c03' },
-};
+const users = [
+  {
+    account: 'employee01@test.com',
+    username: '員工一',
+    password: 'e01e01',
+    role: 'employee',
+  },
+  {
+    account: 'employee02@test.com',
+    username: '員工二',
+    password: 'e02e02',
+    role: 'employee',
+  },
+  {
+    account: 'company01@test.com',
+    username: '廠商一',
+    password: 'c01c01',
+    role: 'company',
+  },
+  {
+    account: 'company02@test.com',
+    username: '廠商二',
+    password: 'c02c02',
+    role: 'company',
+  },
+  {
+    account: 'company03@test.com',
+    username: '廠商三',
+    password: 'c0303',
+    role: 'company',
+  },
+];
 
 // 登入
 function login(req) {
   const requestBody = JSON.parse(req.body);
   const { account, password, role } = requestBody;
-  const user = users[account];
+  const user = users.find((user) => user.account === account);
   const passwordCorrect = user && user.password === password;
   const roleCorrect = passwordCorrect && user.role === role;
 
@@ -29,21 +55,46 @@ function login(req) {
     };
   } else {
     const token = Random.guid();
-    users[account].token = token;
+    user.token = token;
 
     return {
       success: true,
       message: '登入成功',
       payload: {
         token,
-        username: users[account].username,
-        role,
+        // username: users[account].username,
+        // role,
       },
     };
   }
 }
 
+function getProfile(req) {
+  const token = getCookie('token');
+
+  // 找出符合 token 的 使用者
+  const matchedUser = users.find((user) => user.token === token);
+  
+  if (matchedUser) {
+    const { account, username, role } = matchedUser;
+    return {
+      success: true,
+      message: '驗證成功',
+      payload: {
+        account,
+        username,
+        role,
+      },
+    };
+  } else {
+    return {
+      success: false,
+      message: '驗證失敗，請重新登入',
+    };
+  }
+}
 
 export default {
   login,
+  getProfile,
 };

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { getCookie } from '@/utils/cookie.js';
 
 const baseURL = '/api';
 
@@ -6,6 +7,20 @@ const instance = axios.create({
   baseURL,
   timeout: 100000,
 });
+
+// 根據 withToken 決定是否附加 token
+instance.interceptors.request.use(
+  (config) => {
+    if (config.token) {
+      const token = getCookie('token'); // 取得存在 cookie 的 token
+      if (token) {
+        config.headers.Authorization = token;
+      }
+    }
+    return config;
+  },
+  (error) => Promise.reject(error),
+);
 
 // 統一攔截錯誤統一攔截錯誤
 instance.interceptors.response.use(


### PR DESCRIPTION
### 重構：更改取得使用者資訊方式
- 原：直接儲存在 Cookie
- 現：改為打 API 來取得使用者資料，避免使用者直接從 cookie 更改資訊

### 調整
- Navbar 使用者資訊改由 API 取得
- 使用者資料結構

### 新增
- getProfile：取得使用者資料 API
